### PR TITLE
Fix for Travis CI failing on python-base

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # ref: https://docs.travis-ci.com/user/languages/python
 language: python
-dist: trusty
+dist: xenial
 sudo: required
 
 matrix:


### PR DESCRIPTION
This PR solves the problem introduced into python-base from kubernetes-client/python#665. Should solve build failure reported in #92.